### PR TITLE
nixlispBundle.nix: Protect against bash unbound variable error

### DIFF
--- a/nixlispBundle.nix
+++ b/nixlispBundle.nix
@@ -85,7 +85,7 @@ in mkDerivation rec {
     outhash="''${outhash##*/}"
     outhash="''${outhash%%-*}"
     cat > "$out/lib/common-lisp-settings/bundle-path-config.sh" <<EOF
-    if [ -z "\''${_''${outhash}_NIX_LISP_PATH_CONFIG}" ]; then
+    if [ -z "\''${_''${outhash}_NIX_LISP_PATH_CONFIG+x}" ]; then
     export _''${outhash}_NIX_LISP_PATH_CONFIG=1
     export NIX_LISP_ASDF_PATHS="$NIX_LISP_ASDF_PATHS
     $out/lib/common-lisp/bundle"


### PR DESCRIPTION
Tighten the test for an unbound variable so that it won't trigger an error in certain bash setups (as is happening to me in nix-shell on latest nixpkgs.)

See https://stackoverflow.com/a/13864829/1523491