### PR TITLE
Fix unterminated doublequote

### DIFF
--- a/nixlispBundle.nix
+++ b/nixlispBundle.nix
@@ -32,7 +32,7 @@ let
                      (print-backtrace (when uiop-package (find-symbol "PRINT-BACKTRACE" uiop-package))))
                 (if print-backtrace
                     (funcall print-backtrace)
-                    (format t "Early fatal error.  No backtrace.  Good luck!~%)))
+                    (format t "Early fatal error.  No backtrace.  Good luck!~%")))
               (uiop:quit 1)))
 
       (eval-when (:compile-toplevel :load-toplevel :execute)


### PR DESCRIPTION
Fix a syntax error in some Lisp code embedded in Nix code.

Had caused END-OF-FILE errors while bootstrapping ql2nix for me without this fix.