### PR TITLE
Import ql2nix and mkNixlispBundle straight from repository

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,14 +72,14 @@ If you're already using Nixpkgs's ~clwrapper~, then using
 returns in your ~buildInputs~.  ~clwrapper~ will ensure that all of
 the closure's systems are included in ASDF's source registry.  For example,
 
-#+BEGIN_SRC nix
+#+BEGIN_EXAMPLE
 { pkgs ? import <nixpkgs> {} }:
 
 with (import (fetchFromGitHub {
-    owner = "SquircleSpace"
-    repo = "ql2nix";
-    rev = "...";
-    sha256 = "...";
+  owner = "SquircleSpace"
+  repo = "ql2nix";
+  rev = "...";
+  sha256 = "...";
 }) { inherit pkgs; });
 
 let
@@ -90,7 +90,7 @@ pkgs.stdenv.mkDerivation rec {
   buildInputs = [ ql2nix nixlispBundle ];
   # ...
 }
-#+END_SRC
+#+END_EXAMPLE
 
 If you're not using ~clwrapper~, then you'll need to ~LOAD~ the file
 at ~lib/common-lisp/bundle/bundle.lisp~.  This file will configure

--- a/README.org
+++ b/README.org
@@ -72,20 +72,25 @@ If you're already using Nixpkgs's ~clwrapper~, then using
 returns in your ~buildInputs~.  ~clwrapper~ will ensure that all of
 the closure's systems are included in ASDF's source registry.  For example,
 
-#+BEGIN_EXAMPLE
+#+BEGIN_SRC nix
 { pkgs ? import <nixpkgs> {} }:
+
+with (import (fetchFromGitHub {
+    owner = "SquircleSpace"
+    repo = "ql2nix";
+    rev = "...";
+    sha256 = "...";
+}) { inherit pkgs; });
+
 let
-  # Until Nixpkgs adopts mkNixlispBundle, you'll have to embed it in
-  # your project.  Details are below.
-  mkNixlispBundle = import ./nixlisp/mkNixlispBundle.nix pkgs;
-  nixlispBundle = mkNixlispBundle (import ./nixlisp/qlDist.nix);
+  nixlispBundle = mkNixlispBundle ./qlDist.nix;
 in
 pkgs.stdenv.mkDerivation rec {
   name = "example";
-  buildInputs = [ nixlispBundle ];
+  buildInputs = [ ql2nix nixlispBundle ];
   # ...
 }
-#+END_EXAMPLE
+#+END_SRC
 
 If you're not using ~clwrapper~, then you'll need to ~LOAD~ the file
 at ~lib/common-lisp/bundle/bundle.lisp~.  This file will configure

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,24 @@
+# Copyright 2019 Bradley Jensen
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 { pkgs ? import <nixpkgs> {} }:
 
 {

--- a/default.nix
+++ b/default.nix
@@ -1,54 +1,6 @@
-# Copyright 2019 Bradley Jensen
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 { pkgs ? import <nixpkgs> {} }:
-let
-  build = pkgs.writeTextFile {
-    name = "ql2nix-build.lisp";
-    text = ''
-      (require '#:asdf)
-      (let* ((asdf:*central-registry* (cons (truename ".") asdf:*central-registry*))
-             (system (asdf:find-system '#:ql2nix))
-             (uiop:*image-dump-hook* (cons (lambda () (asdf:clear-system system)) uiop:*image-dump-hook*)))
-        (asdf:oos 'asdf:program-op system))
-    '';
-  };
-  clwrapper = pkgs.lispPackages.clwrapper;
-in
-pkgs.stdenv.mkDerivation rec {
-  name = "ql2nix-${version}";
-  version = "1.0.0";
-  src = ./.;
-  buildInputs = [
-    clwrapper
-  ];
-  buildPhase = ''
-    ASDF_OUTPUT_TRANSLATIONS="(:output-translations :ignore-inherited-configuration (t \"$(pwd)\"))"
-    export ASDF_OUTPUT_TRANSLATIONS
-    NIX_LISP_SKIP_CODE=1 source "${clwrapper}/bin/common-lisp.sh" || true
-    "${clwrapper}/bin/common-lisp.sh" "$NIX_LISP_LOAD_FILE" "${build}"
-  '';
-  installPhase = ''
-    mkdir -p "$out/bin"
-    cp ql2nix "$out/bin"
-  '';
-  dontStrip = true;
+
+{
+  ql2nix = import ./ql2nix.nix { inherit pkgs; };
+  mkNixlispBundle = import ./mkNixlispBundle.nix pkgs;
 }

--- a/nixlispDist.nix
+++ b/nixlispDist.nix
@@ -78,9 +78,11 @@ in mkDerivation rec {
 
     mkdir -p "\$1"/archives
     cp "$out/etc/nixlisp/"*.txt "\$1/"
-    for archive in "$out/etc/nixlisp/archives/"*; do
-      cp "\$archive" "\$1"/archives/
-    done
+    if [ -z "$(find "$out/etc/nixlisp/archives/" -maxdepth 0 -empty)" ]; then
+      for archive in "$out/etc/nixlisp/archives/"*; do
+        cp "\$archive" "\$1"/archives/
+      done
+    fi
     EOF
     chmod +x "$out/bin/nixlisp-installer"
     '';


### PR DESCRIPTION
This PR suggests a new default nix with a set, that provides `ql2nix` and `mkNixlispBundle`, so that getting a copy of ql2nix's *.nix files is not necessary.